### PR TITLE
Add `draft-js` as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "watch": "^0.18.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.7.0"
+    "draft-js": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "detect-indent": "^4.0.0",
     "detect-newline": "^2.1.0",
-    "draft-js": "^0.7.0",
     "ends-with": "^0.2.0",
     "immutable": "^3.8.1"
   },
@@ -48,5 +47,8 @@
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "watch": "^0.18.0"
+  },
+  "peerDependencies": {
+    "draft-js": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
-    "draft-js": "^0.7.0",
+    "draft-js": "0.x",
     "draft-js-prism": "^1.0.2",
     "eslint": "^2.11.1",
     "expect": "^1.20.1",
@@ -49,6 +49,6 @@
     "watch": "^0.18.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.9.1"
+    "draft-js": "0.x"
   }
 }


### PR DESCRIPTION
For avoiding dependency duplication on app contexts.

https://github.com/SamyPesse/draft-js-code/issues/9