### PR TITLE
dep: change immutable to ~3.x to facilitate deduping

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "detect-indent": "^4.0.0",
     "detect-newline": "^2.1.0",
     "ends-with": "^0.2.0",
-    "immutable": "^3.8.1"
+    "immutable": "3.x"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
Currently the latest stable release of `immutable` has a dependency on `immutable@~3.7.4`. That semver range is incompatible with this package's semver range for `immutable` - making it impossible to dedupe the dependency.