### PR TITLE
Rename handleTab to onTab

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Returns true if user is editing a code block. You should call this method to enc
 
 Handle key command for code blocks, returns a new `EditorState` or `null`.
 
-##### `CodeUtils.handleTab(e, editorState)`
+##### `CodeUtils.onTab(e, editorState)`
 
 Handle user pressing tab, to insert indentation, it returns a new `EditorState`.
 
@@ -99,11 +99,11 @@ class Editor extends React.Component {
     return 'handled';
   }
 
-  handleTab = (evt) => {
+  onTab = (evt) => {
     const { editorState } = this.state;
     if (!CodeUtils.hasSelectionInBlock(editorState)) return 'not-handled';
 
-    this.onChange(CodeUtils.handleTab(evt, editorState));
+    this.onChange(CodeUtils.onTab(evt, editorState));
     return 'handled';
   }
 
@@ -115,7 +115,7 @@ class Editor extends React.Component {
         keyBindingFn={this.keyBindingFn}
         handleKeyCommand={this.handleKeyCommand}
         handleReturn={this.handleReturn}
-        onTab={this.handleTab}
+        onTab={this.onTab}
       />
     );
   }

--- a/demo/main.js
+++ b/demo/main.js
@@ -118,7 +118,7 @@ class PrismEditorExample extends React.Component {
       return;
     }
 
-    this.onChange(CodeUtils.handleTab(e, editorState));
+    this.onChange(CodeUtils.onTab(e, editorState));
   }
 
   _onReturn(e) {

--- a/lib/__tests__/onTab.test.js
+++ b/lib/__tests__/onTab.test.js
@@ -1,5 +1,5 @@
 const { EditorState, ContentState, SelectionState } = require('draft-js');
-const handleTab = require('../handleTab');
+const onTab = require('../onTab');
 
 const toPlainText = editorState =>
   editorState.getCurrentContent().getPlainText();
@@ -14,7 +14,7 @@ it('should insert a tab', () => {
   const evt = { preventDefault: jest.fn() };
   const initialText = '';
   const before = createWithText(initialText);
-  const after = handleTab(evt, before);
+  const after = onTab(evt, before);
 
   expect(toPlainText(before)).toEqual(initialText);
   expect(toPlainText(after)).toEqual(tabs(1));
@@ -25,7 +25,7 @@ it('should prevent the default event behavior', () => {
   const evt = { preventDefault };
   const before = EditorState.createEmpty();
 
-  handleTab(evt, before);
+  onTab(evt, before);
   expect(preventDefault).toHaveBeenCalled();
 });
 
@@ -33,7 +33,7 @@ it('should add a tab to an existing tab', () => {
   const evt = { preventDefault: jest.fn() };
   const initialText = tabs(1);
   const before = createWithText(initialText);
-  const after = handleTab(evt, before);
+  const after = onTab(evt, before);
 
   expect(toPlainText(before)).toEqual(initialText);
   expect(toPlainText(after)).toEqual(initialText + tabs(1));
@@ -57,7 +57,7 @@ it('should replace selected content with the tab', () => {
     selection: selectInitialtext.set('focusOffset', initialText.length)
   });
 
-  const after = handleTab(evt, before);
+  const after = onTab(evt, before);
   expect(toPlainText(before)).toEqual(initialText);
   expect(toPlainText(after)).toEqual(tabs(1));
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,5 +3,5 @@ module.exports = {
   hasSelectionInBlock: require('./hasSelectionInBlock'),
   handleKeyCommand: require('./handleKeyCommand'),
   handleReturn: require('./handleReturn'),
-  handleTab: require('./handleTab')
+  onTab: require('./onTab')
 };

--- a/lib/onTab.js
+++ b/lib/onTab.js
@@ -10,7 +10,7 @@ var getIndentation = require('./utils/getIndentation');
  * @param {Draft.EditorState} editorState
  * @return {Draft.EditorState}
  */
-function handleTab(e, editorState) {
+function onTab(e, editorState) {
   e.preventDefault();
 
   var contentState = editorState.getCurrentContent();
@@ -42,4 +42,4 @@ function handleTab(e, editorState) {
   );
 }
 
-module.exports = handleTab;
+module.exports = onTab;


### PR DESCRIPTION
For the sake of API consistency with the DraftJS `<Editor />` component it makes sense to rename `handleTab` to the (more expected) `onTab`.

This should resolve some confusion around using this library, as all functions now directly correspond with the editor props.

Closes #28