### PR TITLE
Protection against current code-block removing

### DIFF
--- a/lib/__tests__/handleKeyCommand.js
+++ b/lib/__tests__/handleKeyCommand.js
@@ -1,4 +1,9 @@
-const { EditorState, ContentState, SelectionState } = require('draft-js');
+const {
+  EditorState,
+  ContentState,
+  ContentBlock,
+  SelectionState
+} = require('draft-js');
 const handleKeyCommand = require('../handleKeyCommand');
 
 const toPlainText = editorState =>
@@ -117,6 +122,39 @@ it('should not do anything on backspace if something is selected', () => {
   });
 
   expect(handleKeyCommand(editorState, 'backspace')).toEqual(undefined);
+});
+
+it('should skip handling when text beginning from the content-block beginning', () => {
+  const firstBlock = new ContentBlock({
+    key: 'a1',
+    text: 'const a = 1;',
+    type: 'unstyled'
+  });
+  const secondBlock = new ContentBlock({
+    key: 'a2',
+    text: 'function () {',
+    type: 'code-block'
+  });
+  const currentContent = ContentState.createFromBlockArray([
+    firstBlock,
+    secondBlock
+  ]);
+  const selectSecondBlock = SelectionState.createEmpty(
+    currentContent
+      .getBlockMap()
+      .last()
+      .getKey()
+  )
+    .set('anchorOffset', 0)
+    .set('focusOffset', 0);
+  const editorState = EditorState.create({
+    allowUndo: true,
+    currentContent,
+    selection: selectSecondBlock
+  });
+
+  const after = handleKeyCommand(editorState, 'backspace');
+  expect(toPlainText(after)).toEqual(toPlainText(editorState));
 });
 
 it('should not do anything for any other command', () => {

--- a/lib/utils/getLineAnchorForOffset.js
+++ b/lib/utils/getLineAnchorForOffset.js
@@ -40,7 +40,7 @@ function getLineAnchorForOffset(text, offset, sep) {
   }
 
   return new LineAnchor({
-    line: lineIndex - 1,
+    line: lineIndex === 0 ? 0 : lineIndex - 1,
     offset: offset - lastLineIndex
   });
 }

--- a/lib/utils/removeIndent.js
+++ b/lib/utils/removeIndent.js
@@ -1,8 +1,8 @@
 var Draft = require('draft-js');
 var endsWith = require('ends-with');
+var detectIndent = require('detect-indent');
 
 var getNewLine = require('./getNewLine');
-var getIndentation = require('./getIndentation');
 var getLines = require('./getLines');
 var getLineAnchorForOffset = require('./getLineAnchorForOffset');
 
@@ -26,8 +26,27 @@ function removeIndent(editorState) {
   var blockText = currentBlock.getText();
 
   // Detect newline separator and indentation
+  var indent = detectIndent(blockText);
+
+  // if previous block was not `code-block` and we are at the beginning of line,
+  // we don't do any action to prevent current `code-block` removing
+  if (indent.amount < 1) {
+    var lastBlockBefore = contentState
+      .getBlockMap()
+      .takeUntil((value, key) => {
+        return key.match(startKey);
+      })
+      .last();
+
+    if (
+      !(lastBlockBefore instanceof Draft.ContentBlock) ||
+      lastBlockBefore.getType() !== 'code-block'
+    ) {
+      return editorState;
+    }
+  }
+
   var newLine = getNewLine(blockText);
-  var indent = getIndentation(blockText);
 
   // Get current line
   var lines = getLines(blockText, newLine);

--- a/lib/utils/removeIndent.js
+++ b/lib/utils/removeIndent.js
@@ -3,6 +3,7 @@ var endsWith = require('ends-with');
 var detectIndent = require('detect-indent');
 
 var getNewLine = require('./getNewLine');
+var getIndentation = require('./getIndentation');
 var getLines = require('./getLines');
 var getLineAnchorForOffset = require('./getLineAnchorForOffset');
 
@@ -25,12 +26,26 @@ function removeIndent(editorState) {
   var currentBlock = contentState.getBlockForKey(startKey);
   var blockText = currentBlock.getText();
 
+  var newLine = getNewLine(blockText);
+  var indent = getIndentation(blockText);
+
+  // Get current line
+  var lines = getLines(blockText, newLine);
+  var lineAnchor = getLineAnchorForOffset(blockText, startOffset, newLine);
+
+  var currentLine = lines.get(lineAnchor.getLine());
+  var beforeSelection = currentLine.slice(0, lineAnchor.getOffset());
+
   // Detect newline separator and indentation
-  var indent = detectIndent(blockText);
+  var currentIndent = detectIndent(currentLine);
 
   // if previous block was not `code-block` and we are at the beginning of line,
   // we don't do any action to prevent current `code-block` removing
-  if (indent.amount < 1) {
+  if (
+    currentIndent.amount < 1 &&
+    lineAnchor.getLine() === 0 &&
+    startOffset === 0
+  ) {
     var lastBlockBefore = contentState
       .getBlockMap()
       .takeUntil((value, key) => {
@@ -45,15 +60,6 @@ function removeIndent(editorState) {
       return editorState;
     }
   }
-
-  var newLine = getNewLine(blockText);
-
-  // Get current line
-  var lines = getLines(blockText, newLine);
-  var lineAnchor = getLineAnchorForOffset(blockText, startOffset, newLine);
-
-  var currentLine = lines.get(lineAnchor.getLine());
-  var beforeSelection = currentLine.slice(0, lineAnchor.getOffset());
 
   // If the line before selection ending with the indentation?
   if (!endsWith(beforeSelection, indent)) {


### PR DESCRIPTION
Hi, this should go after previous PRs. We don't need `getIndentation.js` anymore.

When we are at the beginning of line at our `code-block` we can remove it by making attempt to go back to previous indent. Here we are checking the current indent and if it zero and this is the first line of the `code-block`, we do nothing.