### PR TITLE
support 'code' in hasSelectionInBlock (see react-draft-wysiwyg)

### DIFF
--- a/lib/hasSelectionInBlock.js
+++ b/lib/hasSelectionInBlock.js
@@ -10,7 +10,7 @@ function hasSelectionInBlock(editorState) {
   var startKey = selection.getStartKey();
   var currentBlock = contentState.getBlockForKey(startKey);
 
-  return currentBlock.getType() === 'code-block';
+  return ~['code-block', 'code'].indexOf(currentBlock.getType());
 }
 
 module.exports = hasSelectionInBlock;


### PR DESCRIPTION
I'm new to Draft, I don't know if `code-block` is a standard and should be followed, or if you get to make your own or what. https://github.com/jpuri/react-draft-wysiwyg inserts `code`, so this adds support for that (alternatively `~currentBlock.getType().indexOf('code')` in case other editors use `codeblock` or whatever).